### PR TITLE
Issue #27: add swagger result handler test

### DIFF
--- a/boot-static-docs/README.md
+++ b/boot-static-docs/README.md
@@ -1,22 +1,33 @@
 ## boot-static-docs
 
 __Experimental__
-- A spring boot app with a default swagger2 configuration
-- A test which uses `springfox-staticdocs` and [swagger2markup](https://github.com/RobWin/swagger2markup) to generate 
- Asciidoc source from the applications JSO API.
+
+### Contents
+
+- A spring boot [app](src/main/java/springfoxdemo/staticdocs/Application.java) with a default swagger2 configuration
+
+- A [test](src/test/groovy/springfoxdemo/staticdocs/JsonDefinitionTest.groovy) which uses `springfox-staticdocs` to output JSON Swagger definition for the application.
+
+- A [test](src/test/groovy/springfoxdemo/staticdocs/AsciiDocTest.groovy) which uses `springfox-staticdocs` and [swagger2markup](https://github.com/RobWin/swagger2markup) to generate 
+ Asciidoc source (HTML, PDF) from the applications JSON Swagger definition.
+
 - The [asciidoctor-gradle-plugin](https://github.com/asciidoctor/asciidoctor-gradle-plugin) to generate pdf and html asciidoctor docs.
  
+### Running the demo
  
-To generate the asciidoctor documentation run:
+To generate the documentation run:
  
 ```bash
-./gradlew boot-static-docs:asciidoctor
+./gradlew boot-static-docs:test
 ```
 
-### Runnng the app
+Generated documentation artifacts will be found in `build/jsondef` and `build/asciidoc`.
+
+### Running the app
 ```bash
 ./gradlew boot-static-docs:bootRun 
 ```
 
 http://localhost:8080/v2/api-docs
+
 http://localhost:8080/swagger-ui.html

--- a/boot-static-docs/build.gradle
+++ b/boot-static-docs/build.gradle
@@ -24,13 +24,16 @@ dependencies {
   testCompile libs.springfoxStaticDocs
 }
 
-def targetDocDir = "${project.buildDir}/asciidoc/generated/swagger_adoc"
+def asciiDocDir = "${project.buildDir}/asciidoc/generated"
+def jsondefDocDir = "${project.buildDir}/jsondef/generated"
 test {
-  systemProperty "asciiDocOutputDir", targetDocDir
+  systemProperty "asciiDocOutputDir", asciiDocDir
+  systemProperty "jsondefOutputDir", jsondefDocDir
 }
-asciidoctor.dependsOn test
+
+test.finalizedBy asciidoctor
 
 asciidoctor {
-  sourceDir = file(targetDocDir)
+  sourceDir = file(asciiDocDir)
   backends = ['html5', 'pdf']
 }

--- a/boot-static-docs/src/test/groovy/springfoxdemo/staticdocs/AsciiDocTest.groovy
+++ b/boot-static-docs/src/test/groovy/springfoxdemo/staticdocs/AsciiDocTest.groovy
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import springfox.documentation.staticdocs.Swagger2MarkupResultHandler
+import springfox.documentation.staticdocs.SwaggerResultHandler
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
@@ -22,7 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         classes = Application)
 @WebAppConfiguration
 @TestExecutionListeners([DependencyInjectionTestExecutionListener, DirtiesContextTestExecutionListener])
-class StaticDocsTest extends spock.lang.Specification {
+class AsciiDocTest extends spock.lang.Specification {
 
   @Autowired
   WebApplicationContext context;
@@ -32,8 +33,7 @@ class StaticDocsTest extends spock.lang.Specification {
   def setup() {
     this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build()
   }
-
-
+    
   def "generates the petstore api asciidoc"() {
     setup:
       String outDir = System.getProperty('asciiDocOutputDir', 'build/aciidoc')

--- a/boot-static-docs/src/test/groovy/springfoxdemo/staticdocs/JsonDefinitionTest.groovy
+++ b/boot-static-docs/src/test/groovy/springfoxdemo/staticdocs/JsonDefinitionTest.groovy
@@ -1,0 +1,57 @@
+package springfoxdemo.staticdocs
+
+import groovy.io.FileType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestExecutionListeners
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener
+import org.springframework.test.context.web.WebAppConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import springfox.documentation.staticdocs.Swagger2MarkupResultHandler
+import springfox.documentation.staticdocs.SwaggerResultHandler
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ContextConfiguration(
+        loader = SpringApplicationContextLoader,
+        classes = Application)
+@WebAppConfiguration
+@TestExecutionListeners([DependencyInjectionTestExecutionListener, DirtiesContextTestExecutionListener])
+class JsonDefinitionTest extends spock.lang.Specification {
+
+  @Autowired
+  WebApplicationContext context;
+
+  MockMvc mockMvc;
+
+  def setup() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build()
+  }
+
+  def "generates the petstore api swagger json spec"() {
+    setup:
+      String outDir = System.getProperty('jsondefOutputDir', 'build/jsondef')
+      SwaggerResultHandler resultHandler = SwaggerResultHandler
+            .outputDirectory(outDir)
+            .build()
+
+    when:
+      this.mockMvc.perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+            .andDo(resultHandler)
+            .andExpect(status().isOk())
+
+    then:
+      def list = []
+      def dir = new File(resultHandler.outputDir)
+      dir.eachFileRecurse(FileType.FILES) { file ->
+        list << file.name
+      }
+      list.sort() == ['swagger.json']
+  }
+}


### PR DESCRIPTION
Reference: [Issue #27](https://github.com/springfox/springfox-demos/issues/27)

Extends springfox-demos/boot-static-docs to demonstrate usage of SwaggerResultHandler to generate JSON swagger definitions.  

Refactors gradle build to use test task instead of asciidoctor, which is more generic/precise.

Updates README.md to reflect changes.

@dilipkrish @adrianbk 
